### PR TITLE
feat: add deterministic rng for context

### DIFF
--- a/tests/normal_cases.rs
+++ b/tests/normal_cases.rs
@@ -148,3 +148,28 @@ fn test_sighash_all_unlock_data() {
 fn test_sighash_all_unlock_type() {
     test_sighash_all_unlock(ScriptHashType::Type);
 }
+
+#[test]
+fn test_deterministic_rng_context() {
+    let data = BUNDLED_CELL.get("specs/cells/secp256k1_data").unwrap();
+
+    let out_point_1 = {
+        let mut context = Context::default();
+        context.deploy_cell(data.to_vec().into())
+    };
+    let out_point_2 = {
+        let mut context = Context::default();
+        context.deploy_cell(data.to_vec().into())
+    };
+    assert_ne!(out_point_1, out_point_2);
+
+    let out_point_1 = {
+        let mut context = Context::new_with_deterministic_rng();
+        context.deploy_cell(data.to_vec().into())
+    };
+    let out_point_2 = {
+        let mut context = Context::new_with_deterministic_rng();
+        context.deploy_cell(data.to_vec().into())
+    };
+    assert_eq!(out_point_1, out_point_2);
+}


### PR DESCRIPTION
In some unit test, we may need deterministic out point when deploying a contract, for example, in the fiber test code, two nodes need to have the same contract out point to build a commitment tx.

This PR adds a method to allow for a deterministic random number generator to be used to generate the out point when deploy a contract.